### PR TITLE
fix: converter being mutated because of _.merge

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,5 +1,6 @@
 // tslint:disable:no-submodule-imports
 import {
+  IsBoolean,
   ArrayMaxSize,
   ArrayNotContains,
   getFromContainer,
@@ -9,7 +10,7 @@ import {
   MaxLength,
   MetadataStorage,
   MinLength,
-  ValidateNested
+  ValidateNested, Length
 } from 'class-validator'
 import { ValidationMetadata } from 'class-validator/metadata/ValidationMetadata'
 import * as _ from 'lodash'
@@ -36,6 +37,14 @@ class Post {
   @IsOptional()
   @ValidateNested()
   user: User
+
+  @Length(2, 100)
+  @IsOptional()
+  title: string
+
+  @IsBoolean()
+  @IsOptional()
+  published: true
 }
 
 describe('classValidatorConverter', () => {
@@ -73,6 +82,14 @@ describe('classValidatorConverter', () => {
         properties: {
           user: {
             $ref: '#/definitions/User'
+          },
+          title: {
+            maxLength: 100,
+            minLength: 2,
+            "type": "string"
+          },
+          published: {
+            "type": "boolean"
           }
         },
         required: [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ function applyConverters(
   }
 
   // @ts-ignore: array spread
-  return _.merge(...propertyMetadatas.map(convert))
+  return _.merge({}, ...propertyMetadatas.map(convert))
 }
 
 /**


### PR DESCRIPTION
Hi,

First of all, thanks for this project. Really helped to automatically generate the documentation on a work project!

I ran against a small issue with the library. Some "converter" were mutated, which cause some invalid metadata to be generated.

When I had 2 fields with isOptional (CONDITIONAL_VALIDATION that return an empty object), bot of them had the same metadata generated, which would be wrong.

Example

 ```
  @Length(2, 100)
  @IsOptional()
  title: string

  @IsBoolean()
  @IsOptional()
  published: true
```

generated the following metadata:
```
                            "published": {
				"maxLength": 100,
				"minLength": 2,
				"type": "boolean"
			},
			"title": {
				"maxLength": 100,
				"minLength": 2,
				"type": "boolean"
			},
```

This pull request makes sure that `_.merge` applies in into a new object, and not the first one passed as parameter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/epiphone/class-validator-jsonschema/1)
<!-- Reviewable:end -->
