### PR TITLE
Additional properties

### DIFF
--- a/__tests__/additionalProperties.ts
+++ b/__tests__/additionalProperties.ts
@@ -11,14 +11,10 @@ class User {
 
 // @ts-ignore: not referenced
 class Post {
-  // @ts-ignore
-  @ValidateNested({each: true})
-  // @Matches(/w{10}/, {each: true})
   @Type(() => {
     return String
   })
   @MinLength(2, {each: true})
-    // users: User[]
   userStatus: Map<string, string>
 }
 

--- a/__tests__/additionalProperties.ts
+++ b/__tests__/additionalProperties.ts
@@ -1,0 +1,80 @@
+// tslint:disable:no-submodule-imports
+import { IsString, MinLength, ValidateNested } from 'class-validator'
+import { validationMetadatasToSchemas } from '../src'
+import { Type } from 'class-transformer'
+import { defaultMetadataStorage } from 'class-transformer/storage'
+
+class User {
+  @IsString()
+  name: string;
+}
+
+// @ts-ignore: not referenced
+class Post {
+  // @ts-ignore
+  @ValidateNested({each: true})
+  // @Matches(/w{10}/, {each: true})
+  @Type(() => {
+    return String
+  })
+  @MinLength(2, {each: true})
+    // users: User[]
+  userStatus: Map<string, string>
+}
+
+// @ts-ignore: not referenced
+class PostWidthUsers {
+  @ValidateNested({each: true})
+  @Type(() => User)
+  users: Map<string, User>
+}
+
+describe('classValidatorConverter', () => {
+  it('combines converted class-validator metadata into JSON Schemas', async () => {
+    const schemas = validationMetadatasToSchemas({
+      classTransformerMetadataStorage: defaultMetadataStorage,
+    })
+    expect(schemas).toEqual({
+      "User": {
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ]
+      },
+      "Post": {
+        "properties": {
+          "userStatus": {
+            "additionalProperties": {
+              "minLength": 2,
+              "type": "string"
+            },
+            "type": "object"
+          }
+        },
+        "type": "object",
+        "required": [
+          "userStatus"
+        ]
+      },
+      "PostWidthUsers": {
+        "properties": {
+          "users": {
+            "additionalProperties": {
+              "$ref": "#/definitions/User"
+            },
+            "type": "object"
+          }
+        },
+        "type": "object",
+        "required": [
+          "users"
+        ]
+      }
+    })
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,15 +116,13 @@ function applyConverters(
   const converters = { ...defaultConverters, ...options.additionalConverters }
 
   const convert = (meta: ValidationMetadata) => {
-    // @ts-ignore
     const typeMeta = options.classTransformerMetadataStorage
       ? options.classTransformerMetadataStorage.findTypeMetadata(
-        // @ts-ignore
-        meta.target,
-        meta.propertyName
-      )
+          meta.target as Function,
+          meta.propertyName
+        )
       : null
-    const isMap = typeMeta ? new typeMeta.reflectedType() instanceof Map : false;
+    const isMap = typeMeta ? new typeMeta.reflectedType() instanceof Map : false
 
     const converter =
       converters[meta.type] || converters[cv.ValidationTypes.CUSTOM_VALIDATION]
@@ -137,10 +135,10 @@ function applyConverters(
         additionalProperties: {
           ...items,
         },
-        type: "object"
-      };
+        type: 'object',
+      }
     }
-    return meta.each ? {items, type: "array"} : items;
+    return meta.each ? { items, type: 'array' } : items
   }
 
   // @ts-ignore: array spread

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,13 +116,11 @@ function applyConverters(
   const converters = { ...defaultConverters, ...options.additionalConverters }
 
   const convert = (meta: ValidationMetadata) => {
-    const typeMeta = options.classTransformerMetadataStorage
-      ? options.classTransformerMetadataStorage.findTypeMetadata(
-          meta.target as Function,
-          meta.propertyName
-        )
-      : null
-    const isMap = typeMeta ? new typeMeta.reflectedType() instanceof Map : false
+    const typeMeta = options.classTransformerMetadataStorage?.findTypeMetadata(
+      meta.target as Function,
+      meta.propertyName
+    )
+    const isMap = typeMeta && new typeMeta.reflectedType() instanceof Map
 
     const converter =
       converters[meta.type] || converters[cv.ValidationTypes.CUSTOM_VALIDATION]

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,7 +128,6 @@ function applyConverters(
     const items = _.isFunction(converter) ? converter(meta, options) : converter
 
     if (meta.each && isMap) {
-      // @ts-ignore
       return {
         additionalProperties: {
           ...items,


### PR DESCRIPTION
Hi, thanks for the great work! Maybe I am missing something, but when I tried to generate JSON schemas for models with nested map fields I noticed that currently these fields have a type = "array" schema. I changed the applyConverters function to output an array type or an object type with additionalProperties depending on the reflected type. I hope that this can be useful.

```typescript
class User {
  @IsString()
  name: string;
}

class Post {
  @Type(() => {
    return String
  })
  @MinLength(2, {each: true})
  userStatus: Map<string, string>
}

class PostWidthUsers {
  @ValidateNested({each: true})
  @Type(() => User)
  users: Map<string, User>
}

// Schemas
{
      "User": {
        "properties": {
          "name": {
            "type": "string"
          }
        },
        "type": "object",
        "required": [
          "name"
        ]
      },
      "Post": {
        "properties": {
          "userStatus": {
            "additionalProperties": {
              "minLength": 2,
              "type": "string"
            },
            "type": "object"
          }
        },
        "type": "object",
        "required": [
          "userStatus"
        ]
      },
      "PostWidthUsers": {
        "properties": {
          "users": {
            "additionalProperties": {
              "$ref": "#/definitions/User"
            },
            "type": "object"
          }
        },
        "type": "object",
        "required": [
          "users"
        ]
      }
    })
  }
```