### PR TITLE
bugfix: handle undefined typeMeta.reflectedType in convert

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -120,7 +120,7 @@ function applyConverters(
       meta.target as Function,
       meta.propertyName
     )
-    const isMap = typeMeta && new typeMeta.reflectedType() instanceof Map
+    const isMap = typeMeta && typeMeta.reflectedType && new typeMeta.reflectedType() instanceof Map
 
     const converter =
       converters[meta.type] || converters[cv.ValidationTypes.CUSTOM_VALIDATION]


### PR DESCRIPTION
Hello, 

In some cases `typeMeta.reflectedType` may be undefined.

As proceeding to a update of my project's dependencies, I have upgraded:
-  "class-transformer": "^0.3.1",
- "class-validator": "^0.12.2",
- "class-validator-jsonschema": "^2.0.2",

Regards
