### PR TITLE
classValidatorToJsonSchema - Get JSON Schema for a specific class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage
 *.key
 *.secret
 yarn-error.log
+.idea

--- a/__tests__/classValidatorToJsonSchema.test.ts
+++ b/__tests__/classValidatorToJsonSchema.test.ts
@@ -1,0 +1,53 @@
+import { IsString, MinLength } from 'class-validator'
+import { classValidatorToJsonSchema, validationMetadatasToSchemas } from '../src'
+
+export class User {
+  @MinLength(5)
+  @IsString()
+  name: string;
+}
+
+describe('classValidatorToJsonSchema', () => {
+  it('handles default object', async () => {
+    const schema = classValidatorToJsonSchema(User)
+
+    expect(schema).toStrictEqual({
+      properties: {
+        name: { minLength: 5, type: 'string' }
+      },
+      required: ['name'],
+      type: 'object'
+    })
+
+    // Import another User class.
+    const alternativeUserImport = await import('./classes/User')
+
+    /**
+     * By importing another User class with the same name JSON schemas get merged.
+     * User JSON schema now contains properties from the classes/User.ts class as
+     * well (firstName)
+     */
+    const schemas = validationMetadatasToSchemas()
+    expect(Boolean(schemas.User!.properties!.name)).toBeTruthy()
+    expect(Boolean(schemas.User!.properties!.firstName)).toBeTruthy()
+
+    /**
+     * When we get JSON schema for a specific class,
+     * it returns properties specific for that class (without merging)
+     */
+    const schema2 = classValidatorToJsonSchema(User)
+    // Schema stays the same
+    expect(schema).toStrictEqual(schema2)
+
+    const alternativeUserSchema = classValidatorToJsonSchema(alternativeUserImport.User)
+
+    expect(alternativeUserSchema).toStrictEqual({
+      properties: {
+        firstName: { minLength: 5, type: 'string' }
+      },
+      required: ['firstName'],
+      type: 'object'
+    })
+  })
+})
+

--- a/__tests__/classes/User.ts
+++ b/__tests__/classes/User.ts
@@ -1,0 +1,7 @@
+import { IsString, MinLength } from 'class-validator'
+
+export class User {
+  @MinLength(5)
+  @IsString()
+  firstName: string;
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,7 +12,7 @@ module.exports = {
   moduleDirectories: ['node_modules', 'src'],
   moduleFileExtensions: ['ts', 'js', 'json'],
   roots: ['<rootDir>/__tests__'],
-  testPathIgnorePatterns: ['/node_modules/'],
+  testPathIgnorePatterns: ['/node_modules/', '/__tests__/classes'],
   coverageDirectory: 'coverage',
   collectCoverageFrom: ['src/**/*.{ts,tsx,js,jsx}', '!src/**/*.d.ts']
 }


### PR DESCRIPTION
Hello. 

First of all, thank you for amazing package! It is very useful, but in my case I needed ability to extract JSON Schema for a specific class (with duplicate names).

The problem with `validationMetadatasToSchemas` is that it merges schemas with the same names.  

So if I have 1 User class with `name` property and another with `firstName`, JSON Schema will include both (obviously I could use unique names, but for current project I cannot avoid duplicates). 

As a workaround I created a separate function which solves the issue for me and might be useful for someone else as well. 

