### PR TITLE
Fixed old import from class-transformer

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "typescript": "^4.1.3"
   },
   "peerDependencies": {
-    "class-transformer": "0.3.2",
+    "class-transformer": "0.3.1",
     "class-validator": "^0.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "typescript": "^4.1.3"
   },
   "peerDependencies": {
-    "class-transformer": "0.3.1",
+    "class-transformer": "0.2.3 - 0.3.1",
     "class-validator": "^0.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "typescript": "^4.1.3"
   },
   "peerDependencies": {
-    "class-transformer": "^0.2.3",
+    "class-transformer": "0.3.2",
     "class-validator": "^0.12.0"
   }
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,4 +1,4 @@
-import { MetadataStorage as ClassTransformerMetadataStorage } from 'class-transformer/metadata/MetadataStorage' // tslint:disable-line:no-submodule-imports
+import { MetadataStorage as ClassTransformerMetadataStorage } from 'class-transformer/types/MetadataStorage' // tslint:disable-line:no-submodule-imports
 import {
   getMetadataStorage,
   MetadataStorage,

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,4 +1,4 @@
-import { MetadataStorage as ClassTransformerMetadataStorage } from 'class-transformer/types/MetadataStorage' // tslint:disable-line:no-submodule-imports
+import { MetadataStorage as ClassTransformerMetadataStorage } from 'class-transformer/metadata/MetadataStorage' // tslint:disable-line:no-submodule-imports
 import {
   getMetadataStorage,
   MetadataStorage,


### PR DESCRIPTION
Since class-transformer@0.3.2 the `class-transformer/metadata/MetadataStorage` got moved to `class-transformer/types/MetadataStorage`.
https://uiwjs.github.io/npm-unpkg/#/pkg/class-transformer@0.3.1
https://uiwjs.github.io/npm-unpkg/#/pkg/class-transformer@0.3.2

This import change should fix it.

We discovered this b/c our builds failed with this error:
```
node_modules/.pnpm/class-validator-jsonschema@2.1.0_3355ee6f645742ea3fc0591706016b64/node_modules/class-validator-jsonschema/build/options.d.ts(1,68): error TS2307: Cannot find module 'class-transformer/metadata/MetadataStorage' or its corresponding type declarations.
 ERROR  Command failed with exit code 2.
ERROR: Service '<<SERVICE>>' failed to build : The command '/bin/sh -c pnpm run build' returned a non-zero code: 1
```