### PR TITLE
Issue #52: replace lodash with native/sublibs

### DIFF
--- a/__tests__/customValidation.test.ts
+++ b/__tests__/customValidation.test.ts
@@ -5,7 +5,6 @@ import {
   ValidatorConstraint,
   ValidatorConstraintInterface,
 } from 'class-validator'
-import * as _ from 'lodash'
 
 import { validationMetadatasToSchemas } from '../src'
 

--- a/__tests__/decorators.test.ts
+++ b/__tests__/decorators.test.ts
@@ -8,7 +8,7 @@ import {
   MaxLength,
   MetadataStorage,
 } from 'class-validator'
-import * as _ from 'lodash'
+import _get from 'lodash.get'
 
 import { JSONSchema, validationMetadatasToSchemas } from '../src'
 
@@ -42,7 +42,7 @@ class User {
   empty?: string
 }
 
-const metadata = _.get(getFromContainer(MetadataStorage), 'validationMetadatas')
+const metadata = _get(getFromContainer(MetadataStorage), 'validationMetadatas')
 const schemas = validationMetadatasToSchemas(metadata)
 
 describe('decorators', () => {

--- a/__tests__/defaultConverters.test.ts
+++ b/__tests__/defaultConverters.test.ts
@@ -1,6 +1,6 @@
 // tslint:disable:object-literal-sort-keys
 import * as validator from 'class-validator'
-import * as _ from 'lodash'
+import _get from 'lodash.get'
 
 import { validationMetadatasToSchemas } from '../src'
 
@@ -139,7 +139,7 @@ class User {
   @validator.ArrayUnique() arrayUnique: any[]
 }
 
-const metadata = _.get(
+const metadata = _get(
   validator.getFromContainer(validator.MetadataStorage),
   'validationMetadatas'
 )

--- a/__tests__/inheritedProperties.test.ts
+++ b/__tests__/inheritedProperties.test.ts
@@ -11,7 +11,7 @@ import {
   MetadataStorage,
   MinLength,
 } from 'class-validator'
-import * as _ from 'lodash'
+import _get from 'lodash.get'
 
 import { JSONSchema, validationMetadatasToSchemas } from '../src'
 
@@ -65,10 +65,7 @@ class User extends BaseContent {
   @Contains('hello') welcome: string
 }
 
-const metadatas = _.get(
-  getFromContainer(MetadataStorage),
-  'validationMetadatas'
-)
+const metadatas = _get(getFromContainer(MetadataStorage), 'validationMetadatas')
 
 describe('Inheriting validation decorators', () => {
   it('inherits and merges validation decorators from parent class', () => {

--- a/__tests__/options.test.ts
+++ b/__tests__/options.test.ts
@@ -10,7 +10,7 @@ import {
   MetadataStorage,
   ValidateNested,
 } from 'class-validator'
-import * as _ from 'lodash'
+import _get from 'lodash.get'
 
 import { validationMetadatasToSchemas } from '../src'
 
@@ -33,7 +33,7 @@ class Post {
   user: User
 }
 
-const metadata = _.get(getFromContainer(MetadataStorage), 'validationMetadatas')
+const metadata = _get(getFromContainer(MetadataStorage), 'validationMetadatas')
 const defaultSchemas = validationMetadatasToSchemas(metadata)
 
 describe('options', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -748,6 +748,33 @@
       "integrity": "sha512-A3YT/c1oTlyvvW/GQqG86EyqWNrT/tisOIh2mW3YCgcx71TNjiTZA3zYZWA5BCmtsOTXjhliy4c4yEkErw6njA==",
       "dev": true
     },
+    "@types/lodash.get": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.get/-/lodash.get-4.4.6.tgz",
+      "integrity": "sha512-E6zzjR3GtNig8UJG/yodBeJeIOtgPkMgsLjDU3CbgCAPC++vJ0eCMnJhVpRZb/ENqEFlov1+3K9TKtY4UdWKtQ==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
+    "@types/lodash.groupby": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.groupby/-/lodash.groupby-4.6.6.tgz",
+      "integrity": "sha512-kwg3T7Ia63KtDNoQQR8hKrLHCAgrH4I44l5uEMuA6JCbj7DiSccaV4tNV1vbjtAOpX990SolVthJCmBVtRVRgw==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
+    "@types/lodash.merge": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.6.tgz",
+      "integrity": "sha512-IB90krzMf7YpfgP3u/EvZEdXVvm4e3gJbUvh5ieuI+o+XqiNEt6fCzqNRaiLlPVScLI59RxIGZMQ3+Ko/DJ8vQ==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/node": {
       "version": "14.14.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.17.tgz",
@@ -3172,13 +3199,30 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E="
     },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "devDependencies": {
     "@team-griffin/install-self-peers": "^1.1.1",
     "@types/jest": "^26.0.19",
-    "@types/lodash": "^4.14.166",
     "@types/lodash.get": "^4.4.6",
     "@types/lodash.groupby": "^4.6.6",
     "@types/lodash.merge": "^4.6.6",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
   },
   "prettier": {
     "semi": false,
-    "singleQuote": true,
-    "endOfLine": "auto"
+    "singleQuote": true
   },
   "dependencies": {
     "lodash.groupby": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -26,10 +26,12 @@
   },
   "prettier": {
     "semi": false,
-    "singleQuote": true
+    "singleQuote": true,
+    "endOfLine": "auto"
   },
   "dependencies": {
-    "lodash": "^4.17.20",
+    "lodash.groupby": "^4.6.0",
+    "lodash.merge": "^4.6.2",
     "openapi3-ts": "^2.0.0",
     "reflect-metadata": "^0.1.13",
     "tslib": "^2.0.3"
@@ -38,11 +40,15 @@
     "@team-griffin/install-self-peers": "^1.1.1",
     "@types/jest": "^26.0.19",
     "@types/lodash": "^4.14.166",
+    "@types/lodash.get": "^4.4.6",
+    "@types/lodash.groupby": "^4.6.6",
+    "@types/lodash.merge": "^4.6.6",
     "@types/node": "^14.14.7",
     "@types/prettier": "^2.1.6",
     "@types/reflect-metadata": "^0.1.0",
     "codecov": "^3.8.1",
     "jest": "^26.6.3",
+    "lodash.get": "^4.4.2",
     "prettier": "^2.2.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.4.4",

--- a/src/defaultConverters.ts
+++ b/src/defaultConverters.ts
@@ -378,7 +378,7 @@ function getPropType(target: object, property: string) {
 function constraintToSchema(primitive: any): SchemaObject | void {
   const primitives = ['string', 'number', 'boolean']
   const type = typeof primitive
-  if (primitives.indexOf(type) !== -1) {
+  if (primitives.includes(type)) {
     return { type: type as 'string' | 'number' | 'boolean' }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,8 @@ export function validationMetadatasToSchemas(userOptions?: Partial<IOptions>) {
     _groupBy(
       metadatas,
       ({ target }) =>
-        (<any>target)[options.schemaNameField] ?? (<any>target).name
+        target[options.schemaNameField as keyof typeof target] ??
+        (target as Function).name
     )
   ).forEach(([key, ownMetas]) => {
     const target = ownMetas[0].target as Function
@@ -79,8 +80,8 @@ export function validationMetadatasToSchemas(userOptions?: Partial<IOptions>) {
 function getMetadatasFromStorage(
   storage: cv.MetadataStorage
 ): ValidationMetadata[] {
-  const metadatas: ValidationMetadata[] = (<any>storage).validationMetadatas
-  const constraints: ConstraintMetadata[] = (<any>storage).constraintMetadatas
+  const metadatas: ValidationMetadata[] = (storage as any).validationMetadatas
+  const constraints: ConstraintMetadata[] = (storage as any).constraintMetadatas
 
   return metadatas.map((meta) => {
     if (meta.constraintCls) {
@@ -207,11 +208,8 @@ function getRequiredPropNames(
   function isOptional(metas: ValidationMetadata[]) {
     return (
       metas &&
-      metas.some(
-        ({ type }) =>
-          [cv.ValidationTypes.CONDITIONAL_VALIDATION, cv.IS_EMPTY].indexOf(
-            type
-          ) !== -1
+      metas.some(({ type }) =>
+        [cv.ValidationTypes.CONDITIONAL_VALIDATION, cv.IS_EMPTY].includes(type)
       )
     )
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     ],
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
+    "esModuleInterop": true,
     "strictNullChecks": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
A solution for issue #52 (remove lodash as a dependency)
I chose to retain 2 of the `lodash` sublibs (`lodash.merge` and `lodash.groupby`) as PROD dependencies and I also kept `lodash.get` as a DEV dependency for tests (fewer casts needed)