### PR TITLE
feat: add validationMetadataArrayToSchemas and targetConstructorToSchema functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -126,7 +126,7 @@ function getMetadatasFromStorage(
   return populateMatadatasWithConstraints(storage, metadatas)
 }
 
-function populateMatadatasWithConstraints(
+function populateMetadatasWithConstraints(
   storage: cv.MetadataStorage,
   metadatas: ValidationMetadata[]
 ): ValidationMetadata[] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,7 @@ export function targetConstructorToSchema(
     true,
     false
   )
-  metadatas = populateMatadatasWithConstraints(storage, metadatas)
+  metadatas = populateMetadatasWithConstraints(storage, metadatas)
 
   const schemas = validationMetadataArrayToSchemas(metadatas, userOptions)
   return Object.values(schemas).length ? Object.values(schemas)[0] : {}
@@ -123,7 +123,7 @@ function getMetadatasFromStorage(
   storage: cv.MetadataStorage
 ): ValidationMetadata[] {
   const metadatas: ValidationMetadata[] = (storage as any).validationMetadatas
-  return populateMatadatasWithConstraints(storage, metadatas)
+  return populateMetadatasWithConstraints(storage, metadatas)
 }
 
 function populateMetadatasWithConstraints(


### PR DESCRIPTION
Implements #15

Example usage:

```ts
const postSchema = targetConstructorToSchema(Post)

expect(postSchema).toEqual({
  properties: {
    published: {
      type: 'boolean',
    },
    title: {
      maxLength: 100,
      minLength: 2,
      type: 'string',
    },
    user: {
      $ref: '#/definitions/User',
    },
  },
  type: 'object',
})
```
