### PR TITLE
Issue #77: fix bug with `isExcluded` filter on inherited classes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,13 @@ export function validationMetadataArrayToSchemas(
     const target = ownMetas[0].target as Function
     const metas = ownMetas
       .concat(getInheritedMetadatas(target, metadatas))
-      .filter((propMeta) => !isExcluded(propMeta, options))
+      .filter(
+        (propMeta) =>
+          !(
+            isExcluded(propMeta, options) ||
+            isExcluded({ ...propMeta, target }, options)
+          )
+      )
 
     const properties: { [name: string]: SchemaObject } = {}
 


### PR DESCRIPTION
The patch to fix bug, described into #77 issue.

I've added the condition to detect `Exclude` into filterings for `propMeta` with overloaded `target` by the value of target for own class. 