### PR TITLE
feat: add option doNotExcludeDecorator

### DIFF
--- a/__tests__/exclude.test.ts
+++ b/__tests__/exclude.test.ts
@@ -47,4 +47,32 @@ describe('Exclude() decorator', () => {
       },
     })
   })
+
+  it('do not omits Exclude()-decorated properties from output schema', () => {
+    const schema = validationMetadatasToSchemas({
+      classTransformerMetadataStorage: defaultMetadataStorage,
+      doNotExcludeDecorator: true,
+    })
+
+    expect(schema).toEqual({
+      Parent: {
+        properties: {
+          inherited: {},
+          inheritedInternal: {},
+        },
+        type: 'object',
+        required: ['inherited', 'inheritedInternal'],
+      },
+      User: {
+        properties: {
+          id: { type: 'string' },
+          inherited: {},
+          inheritedInternal: {},
+          internal: {},
+        },
+        type: 'object',
+        required: ['id', 'internal', 'inherited', 'inheritedInternal'],
+      },
+    })
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,9 +52,10 @@ export function validationMetadataArrayToSchemas(
     )
   ).forEach(([key, ownMetas]) => {
     const target = ownMetas[0].target as Function
-    const metas = ownMetas
-      .concat(getInheritedMetadatas(target, metadatas))
-      .filter((propMeta) => !isExcluded(propMeta, options))
+    let metas = ownMetas.concat(getInheritedMetadatas(target, metadatas))
+    if (!options.doNotExcludeDecorator) {
+      metas = metas.filter((propMeta) => !isExcluded(propMeta, options))
+    }
 
     const properties: { [name: string]: SchemaObject } = {}
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -40,6 +40,12 @@ export interface IOptions extends ValidatorOptions {
    * Defaults to `name`, i.e., class name.
    */
   schemaNameField: string
+
+  /**
+   * Do not exclude field which decorate with `Exclude` decorator.
+   * Defaults to `false`
+   */
+  doNotExcludeDecorator: boolean
 }
 
 export const defaultOptions: IOptions = {
@@ -47,4 +53,5 @@ export const defaultOptions: IOptions = {
   classValidatorMetadataStorage: getMetadataStorage(),
   refPointerPrefix: '#/definitions/',
   schemaNameField: 'name',
+  doNotExcludeDecorator: false,
 }


### PR DESCRIPTION
I have encountered a problem. I have a Dto that has a field decorated by Exclude, but I don't want it to disappear from the JsonSchema.

```ts

export class TerminalOptionsDto {
  @IsOptional()
  @IsBoolean()
  enable: boolean

  @IsOptional()
  @IsString()
  @Transform(({ value }) =>
    typeof value == 'string' && value.length == 0 ? null : value,
  )
  @Exclude({ toPlainOnly: true, })
  @JSONSchema({ format: 'password', type: 'string', title: '密码' })
  password?: string

  @IsOptional()
  @IsString()
  script?: string
}
```

The `password` is disappear in JSONSchema, but I need it.

So, can add option to disable this feature?