### PR TITLE
exclusive limits should be numbers

### DIFF
--- a/src/defaultConverters.ts
+++ b/src/defaultConverters.ts
@@ -128,13 +128,11 @@ export const defaultConverters: ISchemaConverters = {
     type: 'number',
   }),
   [cv.IS_POSITIVE]: {
-    exclusiveMinimum: true,
-    minimum: 0,
+    exclusiveMinimum: 0,
     type: 'number',
   },
   [cv.IS_NEGATIVE]: {
-    exclusiveMaximum: true,
-    maximum: 0,
+    exclusiveMaximum: 0,
     type: 'number',
   },
   [cv.MIN]: (meta) => ({


### PR DESCRIPTION
In openapi3-ts@2.0.2 they are now using the latest json schema syntax and exclusiveMinimum and Maximum are now numbers:

https://github.com/metadevpro/openapi3-ts/commit/e7a08516a86620a66a16f4552d5b9affd6c77987

This PR changes the default converters accordingly.
