### PR TITLE
Upgrade to `openapi3-ts` v3.0.0

### DIFF
--- a/__tests__/defaultConverters.test.ts
+++ b/__tests__/defaultConverters.test.ts
@@ -198,8 +198,8 @@ describe('defaultConverters', () => {
 
           isDivisibleByInt: { multipleOf: 4, type: 'number' },
           isDivisibleByFloat: { multipleOf: 1.1, type: 'number' },
-          isPositive: { type: 'number', minimum: 0, exclusiveMinimum: true },
-          isNegative: { type: 'number', maximum: 0, exclusiveMaximum: true },
+          isPositive: { type: 'number', exclusiveMinimum: 0 },
+          isNegative: { type: 'number', exclusiveMaximum: 0 },
           max: { type: 'number', maximum: 10 },
           min: { type: 'number', minimum: 1 },
 

--- a/__tests__/inheritedProperties.test.ts
+++ b/__tests__/inheritedProperties.test.ts
@@ -17,7 +17,7 @@ import { JSONSchema, validationMetadatasToSchemas } from '../src'
 
 @JSONSchema({
   description: 'Contains email, password and phone',
-  summary: 'Base object',
+  title: 'Base object',
 })
 class BaseContent {
   @JSONSchema({
@@ -29,7 +29,7 @@ class BaseContent {
 
   @JSONSchema({
     description: 'Password field',
-    summary: 'Password',
+    title: 'Password',
   })
   @IsString()
   @IsOptional()
@@ -41,7 +41,7 @@ class BaseContent {
 }
 
 @JSONSchema({
-  summary: 'User object',
+  title: 'User object',
 })
 // @ts-ignore: not referenced
 class User extends BaseContent {
@@ -57,7 +57,7 @@ class User extends BaseContent {
   password: string
 
   @JSONSchema({
-    summary: 'Mobile phone number',
+    title: 'Mobile phone number',
   })
   @IsOptional()
   phone: string
@@ -82,7 +82,7 @@ describe('Inheriting validation decorators', () => {
         },
         password: {
           description: 'Password field',
-          summary: 'Password',
+          title: 'Password',
           type: 'string',
         },
         phone: {
@@ -92,7 +92,7 @@ describe('Inheriting validation decorators', () => {
         },
       },
       required: ['email', 'phone'],
-      summary: 'Base object',
+      title: 'Base object',
       type: 'object',
     })
 
@@ -117,7 +117,7 @@ describe('Inheriting validation decorators', () => {
         },
         phone: {
           format: 'mobile-phone',
-          summary: 'Mobile phone number',
+          title: 'Mobile phone number',
           type: 'string',
           not: { type: 'null' },
         },
@@ -127,7 +127,7 @@ describe('Inheriting validation decorators', () => {
         },
       },
       required: ['name', 'welcome', 'email'],
-      summary: 'User object',
+      title: 'User object',
       type: 'object',
     })
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "lodash.groupby": "^4.6.0",
         "lodash.merge": "^4.6.2",
-        "openapi3-ts": "^2.0.2",
+        "openapi3-ts": "^3.0.0",
         "reflect-metadata": "^0.1.13",
         "tslib": "^2.4.1"
       },
@@ -3233,11 +3233,11 @@
       }
     },
     "node_modules/openapi3-ts": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-2.0.2.tgz",
-      "integrity": "sha512-TxhYBMoqx9frXyOgnRHufjQfPXomTIHYKhSKJ6jHfj13kS8OEIhvmE8CTuQyKtjjWttAjX5DPxM1vmalEpo8Qw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-3.1.2.tgz",
+      "integrity": "sha512-S8fijNOqe/ut0kEDAwHZnI7sVYqb8Q3XnISmSyXmK76jgrcf4ableI75KTY1qdksd9EI/t39Vi5M4VYKrkNKfQ==",
       "dependencies": {
-        "yaml": "^1.10.2"
+        "yaml": "^2.1.3"
       }
     },
     "node_modules/p-limit": {
@@ -4379,11 +4379,11 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
+      "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/yargs": {
@@ -6904,11 +6904,11 @@
       }
     },
     "openapi3-ts": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-2.0.2.tgz",
-      "integrity": "sha512-TxhYBMoqx9frXyOgnRHufjQfPXomTIHYKhSKJ6jHfj13kS8OEIhvmE8CTuQyKtjjWttAjX5DPxM1vmalEpo8Qw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-3.1.2.tgz",
+      "integrity": "sha512-S8fijNOqe/ut0kEDAwHZnI7sVYqb8Q3XnISmSyXmK76jgrcf4ableI75KTY1qdksd9EI/t39Vi5M4VYKrkNKfQ==",
       "requires": {
-        "yaml": "^1.10.2"
+        "yaml": "^2.1.3"
       }
     },
     "p-limit": {
@@ -7749,9 +7749,9 @@
       "dev": true
     },
     "yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
+      "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw=="
     },
     "yargs": {
       "version": "17.6.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "lodash.groupby": "^4.6.0",
     "lodash.merge": "^4.6.2",
-    "openapi3-ts": "^2.0.2",
+    "openapi3-ts": "^3.0.0",
     "reflect-metadata": "^0.1.13",
     "tslib": "^2.4.1"
   },

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -1,5 +1,5 @@
 // tslint:disable:ban-types
-import { SchemaObject } from 'openapi3-ts'
+import type { ReferenceObject, SchemaObject } from 'openapi3-ts'
 import 'reflect-metadata'
 
 import { IOptions } from './options'
@@ -12,8 +12,12 @@ const SCHEMA_KEY = Symbol('class-validator-jsonschema:JSONSchema')
  * options, returning an updated schema.
  */
 export type DecoratorSchema =
+  | ReferenceObject
   | SchemaObject
-  | ((source: SchemaObject, options: IOptions) => SchemaObject)
+  | ((
+      source: SchemaObject,
+      options: IOptions
+    ) => ReferenceObject | SchemaObject)
 
 /**
  * Supplement class or property with additional JSON Schema keywords.

--- a/src/defaultConverters.ts
+++ b/src/defaultConverters.ts
@@ -126,13 +126,11 @@ export const defaultConverters: ISchemaConverters = {
     type: 'number',
   }),
   [cv.IS_POSITIVE]: {
-    exclusiveMinimum: true,
-    minimum: 0,
+    exclusiveMinimum: 0,
     type: 'number',
   },
   [cv.IS_NEGATIVE]: {
-    exclusiveMaximum: true,
-    maximum: 0,
+    exclusiveMaximum: 0,
     type: 'number',
   },
   [cv.MIN]: (meta) => ({

--- a/src/defaultConverters.ts
+++ b/src/defaultConverters.ts
@@ -1,7 +1,7 @@
 // tslint:disable:no-submodule-imports
 import * as cv from 'class-validator'
-import { ValidationMetadata } from 'class-validator/types/metadata/ValidationMetadata'
-import { SchemaObject } from 'openapi3-ts'
+import type { ValidationMetadata } from 'class-validator/types/metadata/ValidationMetadata'
+import type { ReferenceObject, SchemaObject } from 'openapi3-ts'
 import 'reflect-metadata'
 
 import { IOptions } from './options'
@@ -13,7 +13,7 @@ export interface ISchemaConverters {
 export type SchemaConverter = (
   meta: ValidationMetadata,
   options: IOptions
-) => SchemaObject | void
+) => ReferenceObject | SchemaObject | void
 
 export const defaultConverters: ISchemaConverters = {
   [cv.ValidationTypes.CUSTOM_VALIDATION]: (meta, options) => {
@@ -381,7 +381,10 @@ function constraintToSchema(primitive: any): SchemaObject | void {
   }
 }
 
-function targetToSchema(type: any, options: IOptions): SchemaObject | void {
+function targetToSchema(
+  type: any,
+  options: IOptions
+): ReferenceObject | SchemaObject | void {
   if (typeof type === 'function') {
     if (
       type.prototype === String.prototype ||

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import * as cv from 'class-validator'
 import { ValidationMetadata } from 'class-validator/types/metadata/ValidationMetadata'
 import _groupBy from 'lodash.groupby'
 import _merge from 'lodash.merge'
-import { SchemaObject } from 'openapi3-ts'
+import type { ReferenceObject, SchemaObject } from 'openapi3-ts'
 
 import { getMetadataSchema } from './decorators'
 import { defaultConverters } from './defaultConverters'
@@ -65,7 +65,7 @@ export function validationMetadataArrayToSchemas(
           )
       )
 
-    const properties: { [name: string]: SchemaObject } = {}
+    const properties: { [name: string]: ReferenceObject | SchemaObject } = {}
 
     Object.entries(_groupBy(metas, 'propertyName')).forEach(
       ([propName, propMetas]) => {
@@ -94,7 +94,7 @@ export function validationMetadataArrayToSchemas(
       target,
       options,
       target.name
-    )
+    ) as SchemaObject
   })
 
   return schemas
@@ -241,7 +241,7 @@ function applyDecorators(
   target: Function,
   options: IOptions,
   propertyName: string
-): SchemaObject {
+): ReferenceObject | SchemaObject {
   const additionalSchema = getMetadataSchema(target.prototype, propertyName)
   return typeof additionalSchema === 'function'
     ? additionalSchema(schema, options)


### PR DESCRIPTION
Supersedes https://github.com/epiphone/class-validator-jsonschema/pull/90.

Breaking changes:
- The `JSONSchema` decorator parameter type uses updated JSON Schema type from openapi3-ts v3.
- `IsPositive` and `IsNegative` class-validator decorators now produce output like `{ "exclusiveMinimum": 0 }` instead of `{ "minimum": 0, "exclusiveMinimum": true }` (see [JSON Schema docs](https://json-schema.org/understanding-json-schema/reference/numeric.html#id7)).