### PR TITLE
feat: nested type proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,23 +207,37 @@ users: UserClass[]
 user: Promise<UserClass>
 ```
 
-would resolve to classes `Array` and `Promise` in JSON Schema. To work around this limitation we can use `@Type` from `class-transformer` to explicitly define the nested property's inner type:
+would resolve to classes `Array` and `Promise` in JSON Schema. To work around this limitation we can use:
 
-```typescript
-import { Type } from 'class-transformer'
-import { validationMetadatasToSchemas } from 'class-validator-jsonschema'
-const { defaultMetadataStorage } = require('class-transformer/cjs/storage') // See https://github.com/typestack/class-transformer/issues/563 for alternatives
+* Option 1: `@NestedType`decorator
+  ```typescript
+  @ValidateNested()
+  @NestedType(() => NestedClass)
+  nestedTypeWithObject: NestedClass | null | undefined;
 
-class User {
   @ValidateNested({ each: true })
-  @Type(() => BlogPost) // 1) Explicitly define the nested property type
-  blogPosts: BlogPost[]
-}
+  @NestedType(() => NestedClass)
+  nestedTypeWithArray: NestedClass[]
+  ```
 
-const schemas = validationMetadatasToSchemas({
-  classTransformerMetadataStorage: defaultMetadataStorage, // 2) Define class-transformer metadata in options
-})
-```
+* Option 2: `@Type` from `class-transformer`
+  When using class-transformer this decorator can be reused to explicitly define the nested property's inner type:
+
+  "```typescript
+  import { Type } from 'class-transformer'
+  import { validationMetadatasToSchemas } from 'class-validator-jsonschema'
+  const { defaultMetadataStorage } = require('class-transformer/cjs/storage') // See https://github.com/typestack/class-transformer/issues/563 for alternatives
+
+  class User {
+    @ValidateNested({ each: true })
+    @Type(() => BlogPost) // 1) Explicitly define the nested property type
+    blogPosts: BlogPost[]
+  }
+
+  const schemas = validationMetadatasToSchemas({
+    classTransformerMetadataStorage: defaultMetadataStorage, // 2) Define class-transformer metadata in options
+  })
+  ```
 
 Note also how the `classTransformerMetadataStorage` option has to be defined for `@Type` decorator to take effect.
 

--- a/__tests__/nestedTypeDecorator.test.ts
+++ b/__tests__/nestedTypeDecorator.test.ts
@@ -1,0 +1,86 @@
+import {
+    IsOptional,
+    IsString,
+    ValidateNested,
+} from 'class-validator'
+
+import { validationMetadatasToSchemas } from '../src'
+import { NestedType as NestedType } from '../src/decorators'
+
+class SubnestedClass {
+    @IsString()
+    normalAttr3: string;
+}
+
+class NestedClass {
+    @IsString()
+    normalAttr2: string;
+
+    @IsOptional()
+    @ValidateNested()
+    @NestedType(() => SubnestedClass)
+    subnestedTypeWithObject: SubnestedClass | null | undefined;
+
+    @IsOptional()
+    @ValidateNested({ each: true })
+    @NestedType(() => SubnestedClass)
+    subnestedTypeWithArray: SubnestedClass[]
+}
+
+export class NestedTypeTestMainClass {
+    @IsOptional()
+    @IsString()
+    normalAttr: string;
+
+    @ValidateNested()
+    @NestedType(() => NestedClass)
+    nestedTypeWithObject: NestedClass | null | undefined;
+
+    @ValidateNested({ each: true })
+    @NestedType(() => NestedClass)
+    nestedTypeWithArray: NestedClass[]
+}
+
+describe('NestedType tests', () => {
+    it('The NestedType works with arrays or objects', () => {
+        const schemas = validationMetadatasToSchemas()
+        expect(schemas.NestedTypeTestMainClass).toEqual({
+            properties: {
+                nestedTypeWithObject: {
+                    $ref: '#/definitions/NestedClass'
+                },
+                nestedTypeWithArray: {
+                    items: {
+                        $ref: '#/definitions/NestedClass',
+                    },
+                    type: 'array',
+                },
+                normalAttr: {
+                    type: 'string',
+                },
+            },
+            required: ['nestedTypeWithObject', 'nestedTypeWithArray'],
+            type: 'object'
+        })
+
+        expect(schemas.NestedClass).toEqual({
+            properties: {
+                subnestedTypeWithObject: {
+                    $ref: '#/definitions/SubnestedClass'
+                },
+                subnestedTypeWithArray: {
+                    items: {
+                        $ref: '#/definitions/SubnestedClass'
+                    },
+                    type: 'array',
+                },
+                normalAttr2: {
+                    type: 'string',
+                },
+            },
+            required: ['normalAttr2'],
+            type: 'object'
+        })
+    })
+
+})

--- a/__tests__/nestedTypeDecorator.test.ts
+++ b/__tests__/nestedTypeDecorator.test.ts
@@ -5,7 +5,7 @@ import {
 } from 'class-validator'
 
 import { validationMetadatasToSchemas } from '../src'
-import { NestedType as NestedType } from '../src/decorators'
+import { NestedType } from '../src/decorators'
 
 class SubnestedClass {
     @IsString()

--- a/src/defaultConverters.ts
+++ b/src/defaultConverters.ts
@@ -2,6 +2,7 @@
 import * as cv from 'class-validator'
 import type { ValidationMetadata } from 'class-validator/types/metadata/ValidationMetadata'
 import type { ReferenceObject, SchemaObject } from 'openapi3-ts'
+import { getMetadataNestedType } from './decorators'
 import 'reflect-metadata'
 
 import { IOptions } from './options'
@@ -24,6 +25,11 @@ export const defaultConverters: ISchemaConverters = {
   },
   [cv.ValidationTypes.NESTED_VALIDATION]: (meta, options) => {
     if (typeof meta.target === 'function') {
+      const nestedSchemaTypeFunction = getMetadataNestedType(meta.target, meta.propertyName)
+      if (nestedSchemaTypeFunction) {
+        return targetToSchema(nestedSchemaTypeFunction(), options)
+      }
+
       const typeMeta = options.classTransformerMetadataStorage
         ? options.classTransformerMetadataStorage.findTypeMetadata(
             meta.target,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { getMetadataSchema } from './decorators'
 import { defaultConverters } from './defaultConverters'
 import { defaultOptions, IOptions } from './options'
 
-export { JSONSchema } from './decorators'
+export { JSONSchema, NestedType } from './decorators'
 
 type IStorage = {
   validationMetadatas: Map<Function | string, ValidationMetadata[]>


### PR DESCRIPTION
Currently without using the class-transformer there is no option to work with the nested elements and also with troubles related with this https://github.com/typestack/class-transformer/issues/563

This is a proposal to create a decorator for that purpose without depending on class-transformer, when you are using only class-validator decorators

Usage
```
@ValidateNested()
@NestedType(() => NestedClass)
nestedTypeWithObject: NestedClass | null | undefined;

@ValidateNested({ each: true })
@NestedType(() => NestedClass)
nestedTypeWithArray: NestedClass[]
```

The decorator is not altering the previous behavior, so, no regressions or breaking changes are expected. The decorator is only taken into account when present in a class attribute, in that case, it will have preference when detecting the nested type.

The name of the decorator is only a proposal

I hope you find this useful
Greetings 😄 
