### PR TITLE
(fix) Handled the case of passing a function that returns a date to the MaxDate decorator

### DIFF
--- a/src/defaultConverters.ts
+++ b/src/defaultConverters.ts
@@ -26,9 +26,9 @@ export const defaultConverters: ISchemaConverters = {
     if (typeof meta.target === 'function') {
       const typeMeta = options.classTransformerMetadataStorage
         ? options.classTransformerMetadataStorage.findTypeMetadata(
-            meta.target,
-            meta.propertyName
-          )
+          meta.target,
+          meta.propertyName
+        )
         : null
       const childType = typeMeta
         ? typeMeta.typeFunction()
@@ -141,15 +141,18 @@ export const defaultConverters: ISchemaConverters = {
     maximum: meta.constraints[0],
     type: 'number',
   }),
-  [cv.MIN_DATE]: (meta) => ({
-    description: `After ${meta.constraints[0].toJSON()}`,
-    oneOf: [
-      { format: 'date', type: 'string' },
-      { format: 'date-time', type: 'string' },
-    ],
-  }),
+  [cv.MIN_DATE]: (meta) => {
+    const description = typeof meta.constraints[0] === 'function' ? `After a date computed dynamically` : `After ${meta.constraints[0]}`;
+    return {
+      description,
+      oneOf: [
+        { format: 'date', type: 'string' },
+        { format: 'date-time', type: 'string' },
+      ],
+    }
+  },
   [cv.MAX_DATE]: (meta) => {
-    const description= typeof meta.constraints[0] === 'function' ? `Before a date computed dynamically` : `Before ${meta.constraints[0]}`;
+    const description = typeof meta.constraints[0] === 'function' ? `Before a date computed dynamically` : `Before ${meta.constraints[0]}`;
     return {
       description,
       oneOf: [

--- a/src/defaultConverters.ts
+++ b/src/defaultConverters.ts
@@ -148,13 +148,16 @@ export const defaultConverters: ISchemaConverters = {
       { format: 'date-time', type: 'string' },
     ],
   }),
-  [cv.MAX_DATE]: (meta) => ({
-    description: `Before ${meta.constraints[0].toJSON()}`,
-    oneOf: [
-      { format: 'date', type: 'string' },
-      { format: 'date-time', type: 'string' },
-    ],
-  }),
+  [cv.MAX_DATE]: (meta) => {
+    const description= typeof meta.constraints[0] === 'function' ? `Before a date computed dynamically` : `Before ${meta.constraints[0]}`;
+    return {
+      description,
+      oneOf: [
+        { format: 'date', type: 'string' },
+        { format: 'date-time', type: 'string' },
+      ],
+    }
+  },
   [cv.IS_BOOLEAN_STRING]: {
     enum: ['true', 'false'],
     type: 'string',


### PR DESCRIPTION
I tried to use the library in an app that tried to validate a date field, ensuring the date is in the past (before `Date.now()`).

It failed because the library tried to run toJSON() on a function and now I am trying to push a fix for that use case.
It just replaces the description of the field with this description `Before a date computed dynamically`.

Did the same for the MinDate decorator as well.